### PR TITLE
added validation to error coercion to stop error processing before it…

### DIFF
--- a/flask_io/utils.py
+++ b/flask_io/utils.py
@@ -1,40 +1,37 @@
 import sys
-from collections import Mapping
+from collections import Mapping, Sequence
 
 from flask import request, _compat
 from time import perf_counter
 from marshmallow.marshalling import SCHEMA
 from werkzeug.http import HTTP_STATUS_CODES
 
-from marshmallow.exceptions import MarshmallowError
-from .errors import Error, APIError
+from .errors import Error
 
 
-_VALID_ERROR_TYPES = (Error, APIError, MarshmallowError, str)
-
-
-def _validate_error_types(errors):
-    if not isinstance(errors, _VALID_ERROR_TYPES):
-        if issubclass(type(errors), list):
-            if all(issubclass(type(err), (Mapping,) + _VALID_ERROR_TYPES)
-                   for err in errors):
-                return
-        raise TypeError('Invalid error object of type: {}'.format(
-                        type(errors)))
+def _raise_typeerror(error):
+    raise TypeError('Invalid error object of type {}'.format(type(error)))
 
 
 def errors_to_dict(errors):
-    _validate_error_types(errors)
-
-    if isinstance(errors, str):
-        errors = [Error(errors)]
-    elif not isinstance(errors, list):
-        errors = [errors]
-
     errors_data = []
 
-    for error in errors:
-        errors_data.append(error.as_dict())
+    if isinstance(errors, str):
+        errors_data = [Error(errors).as_dict()]
+
+    elif hasattr(errors, 'as_dict'):
+        errors_data = [errors.as_dict()]
+
+    elif isinstance(errors, Sequence) and isinstance(errors[0], Mapping):
+        errors_data = errors
+
+    elif isinstance(errors, Sequence):
+        errors_data = [error.as_dict()
+                       if hasattr(error, 'as_dict')
+                       else _raise_typeerror(error)
+                       for error in errors]
+    else:
+        _raise_typeerror(errors)
 
     return dict(errors=errors_data)
 
@@ -99,7 +96,7 @@ def http_status_message(code):
 
 def marshal(data, schema, envelope=None):
     if data is not None:
-        many = isinstance(data, list)
+        many = isinstance(data, Sequence)
         data = schema.dump(data, many=many).data
 
     if envelope:
@@ -121,7 +118,7 @@ def unpack(value):
 def validation_error_to_errors(validation_error):
     errors = []
 
-    if isinstance(validation_error.messages, list):
+    if isinstance(validation_error.messages, Sequence):
         field_names = validation_error.field_names or [SCHEMA]
 
         for field in field_names:
@@ -138,7 +135,7 @@ def validation_error_to_error(field, error, location, errors):
     if isinstance(error, dict):
         for f, e in error.items():
             validation_error_to_error(f, e, location, errors)
-    elif isinstance(error, list):
+    elif isinstance(error, Sequence):
         error = error[0]
         if isinstance(error, str):
             errors.append(Error(error, location=location, field=field))


### PR DESCRIPTION
… hits the stdlib json module.

Currently an error object of an invalid type (a non-mapping or object that does not implement .as_dict) will make it all the way to the json module, where the user is given a very large traceback informing them that "o.items() is not iterable". This is uninformative and awkward.

This is changed so that the user is informed that the object they are passing as an error is invalid, and the object's type is displayed, like

`Invalid error object of type: <class 'int'>`