### PR TITLE
Fix deprecation warning

### DIFF
--- a/flask_io/utils.py
+++ b/flask_io/utils.py
@@ -1,5 +1,5 @@
 import sys
-from collections import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 from flask import request, _compat
 from time import perf_counter


### PR DESCRIPTION
This change will resolve the deprecation warning shown below:
flask_io/utils.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, Sequence