### PR TITLE
Modify to use marshmallow 3 and flask 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+2.*
+++++++++++++++++++
+- Removed support for use of python versions <=3.5
+- Updated to use any Flask version 2.x
+- Updated to use any marshmallow version 3.x 
+
 1.14.3
 ++++++++++++++++++
 - Fix deprecation warning [#6](https://github.com/viniciuschiele/flask-io/pull/6)

--- a/flask_io/fields.py
+++ b/flask_io/fields.py
@@ -43,9 +43,9 @@ class DelimitedList(List):
         values = super()._serialize(value, attr, obj)
         return self.delimiter.join(format(v) for v in values)
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         values = value.split(self.delimiter)
-        return super()._deserialize(values, attr, data)
+        return super()._deserialize(values, attr, data, **kwargs)
 
 
 class Enum(Field):
@@ -72,9 +72,9 @@ class Enum(Field):
                 value = self.__member_type(value)
             return self.enum_type(value).value
         except:
-            self.fail('validator_failed')
+            raise self.make_error('validator_failed')
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         try:
             if type(value) is self.enum_type:
                 return value
@@ -82,7 +82,7 @@ class Enum(Field):
                 value = self.__member_type(value)
             return self.enum_type(value)
         except:
-            self.fail('validator_failed')
+            raise self.make_error('validator_failed')
 
 
 class Password(Field):
@@ -143,8 +143,8 @@ class String(fields.String):
         self.only_numeric = self.only_numeric if only_numeric is None else only_numeric
         self.upper = self.upper if upper is None else upper
 
-    def _deserialize(self, value, attr, data):
-        value = super()._deserialize(value, attr, data)
+    def _deserialize(self, value, attr, data, **kwargs):
+        value = super()._deserialize(value, attr, data, **kwargs)
 
         if value is None:
             return value
@@ -162,13 +162,13 @@ class String(fields.String):
 
     def _validate(self, value):
         if not self.allow_empty and value == '':
-            self.fail('empty')
+            raise self.make_error('empty')
 
         if not self.allow_none and value is None:
-            self.fail('null')
+            raise self.make_error('null')
 
         if self.only_numeric and value and not value.isnumeric():
-            self.fail('only_numeric')
+            raise self.make_error('only_numeric')
 
         if value is not None:
             super()._validate(value)
@@ -188,8 +188,8 @@ class UUID(fields.UUID):
         super().__init__(*args, **kwargs)
         self.as_text = as_text
 
-    def _deserialize(self, value, attr, data):
-        value_as_uuid = super()._deserialize(value, attr, data)
+    def _deserialize(self, value, attr, data, **kwargs):
+        value_as_uuid = super()._deserialize(value, attr, data, **kwargs)
 
         if self.as_text:
             return value

--- a/flask_io/utils.py
+++ b/flask_io/utils.py
@@ -1,7 +1,7 @@
 import sys
 from collections.abc import Mapping, Sequence
 
-from flask import request, _compat
+from flask import request
 from time import perf_counter
 from marshmallow.exceptions import SCHEMA
 from werkzeug.http import HTTP_STATUS_CODES
@@ -106,8 +106,10 @@ def marshal(data, schema, envelope=None):
 
 
 def reraise():
-    exc_type, exc_value, tb = sys.exc_info()
-    _compat.reraise(exc_type, exc_value, tb)
+    _, exc_value, tb = sys.exc_info()
+    if exc_value.__traceback__ is not tb:
+        raise exc_value.with_traceback(tb)
+    raise exc_value
 
 
 def unpack(value):

--- a/flask_io/utils.py
+++ b/flask_io/utils.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 
 from flask import request, _compat
 from time import perf_counter
-from marshmallow.marshalling import SCHEMA
+from marshmallow.exceptions import SCHEMA
 from werkzeug.http import HTTP_STATUS_CODES
 
 from .errors import Error
@@ -97,7 +97,7 @@ def http_status_message(code):
 def marshal(data, schema, envelope=None):
     if data is not None:
         many = isinstance(data, Sequence)
-        data = schema.dump(data, many=many).data
+        data = schema.dump(data, many=many)
 
     if envelope:
         return {envelope: data}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask>=0.10.1,<=1.1.4
+flask>=0.10.1,<=2.0.3
 python-dateutil>=2.4.2
 marshmallow>=3.0.0,<=3.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask>=0.10.1,<=2.0.3
+flask>=2,<3
 python-dateutil>=2.4.2
-marshmallow>=3.0.0,<=3.14.1
+marshmallow>=3,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask>=0.10.1
+flask>=0.10.1,<=1.1.4
 python-dateutil>=2.4.2
-marshmallow>=2.9.1,<3
+marshmallow>=3.0.0,<=3.14.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='vinicius.chiele@gmail.com',
     description='Flask-IO is a library for parsing Flask request arguments into parameters and for serialization of complex objects into Flask response.',
     keywords=['flask', 'rest', 'parse', 'encode', 'decode', 'request', 'json', 'marshmallow'],
-    install_requires=['flask>=0.10.1', 'python-dateutil>=2.4.2', 'marshmallow>=2.9.1,<3'],
+    install_requires=['flask>=0.10.1,<=1.1.4', 'python-dateutil>=2.4.2', 'marshmallow>=3.0.0,<=3.14.1'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='vinicius.chiele@gmail.com',
     description='Flask-IO is a library for parsing Flask request arguments into parameters and for serialization of complex objects into Flask response.',
     keywords=['flask', 'rest', 'parse', 'encode', 'decode', 'request', 'json', 'marshmallow'],
-    install_requires=['flask>=0.10.1,<=1.1.4', 'python-dateutil>=2.4.2', 'marshmallow>=3.0.0,<=3.14.1'],
+    install_requires=['flask>=0.10.1,<=2.0.3', 'python-dateutil>=2.4.2', 'marshmallow>=3.0.0,<=3.14.1'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='vinicius.chiele@gmail.com',
     description='Flask-IO is a library for parsing Flask request arguments into parameters and for serialization of complex objects into Flask response.',
     keywords=['flask', 'rest', 'parse', 'encode', 'decode', 'request', 'json', 'marshmallow'],
-    install_requires=['flask>=0.10.1,<=2.0.3', 'python-dateutil>=2.4.2', 'marshmallow>=3.0.0,<=3.14.1'],
+    install_requires=['flask>=2,<3', 'python-dateutil>=2.4.2', 'marshmallow>=3,<4'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -18,9 +18,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython'
     ]
 )

--- a/tests/test_request_args.py
+++ b/tests/test_request_args.py
@@ -44,7 +44,7 @@ class TestRequestArgs(TestCase):
 
     def test_default_value(self):
         @self.app.route('/resource', methods=['GET'])
-        @self.io.from_query('param1', fields.Int(missing=10))
+        @self.io.from_query('param1', fields.Int(load_default=10))
         def test(param1):
             self.assertEqual(param1, 10)
         response = self.client.get('/resource')
@@ -74,9 +74,9 @@ class TestRequestArgs(TestCase):
         response = self.client.get('/resource?param1=11')
         self.assertEqual(response.status_code, 400)
 
-    def test_load_from(self):
+    def test_data_key(self):
         @self.app.route('/resource', methods=['GET'])
-        @self.io.from_query('param2', fields.Integer(load_from='param1'))
+        @self.io.from_query('param2', fields.Integer(data_key='param1'))
         def test(param2):
             self.assertEqual(param2, 10)
         response = self.client.get('/resource?param1=10')

--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -30,7 +30,7 @@ class TestRequestBody(TestCase):
             self.assertEqual(user.username, 'user1')
             self.assertEqual(user.password, 'pass1')
 
-        data = UserSchema().dump(User('user1', 'p')).data
+        data = UserSchema().dump(User('user1', 'p'))
 
         headers = {'content-type': 'application/json'}
         response = self.client.post('/resource', data=json.dumps(data), headers=headers)
@@ -44,7 +44,7 @@ class TestRequestBody(TestCase):
             self.assertEqual(user.username, 'user1')
             self.assertEqual(user.password, 'pass1')
 
-        data = UserSchema().dump(User('user1', 'pass1')).data
+        data = UserSchema().dump(User('user1', 'pass1'))
 
         headers = {'content-type': 'application/json'}
         response = self.client.post('/resource', data=json.dumps(data), headers=headers)
@@ -67,7 +67,7 @@ class TestRequestBody(TestCase):
             self.assertEqual(user.username, 'user1')
             self.assertEqual(user.password, 'pass1')
 
-        data = UserSchema().dump(User('user1', 'pass1')).data
+        data = UserSchema().dump(User('user1', 'pass1'))
 
         response = self.client.post('/resource', data=json.dumps(data))
         self.assertEqual(response.status_code, 204)
@@ -78,7 +78,7 @@ class TestRequestBody(TestCase):
         def test(user):
             pass
 
-        data = UserSchema().dump(User('user1', 'pass1')).data
+        data = UserSchema().dump(User('user1', 'pass1'))
 
         headers = {'content-type': 'application/data'}
         response = self.client.post('/resource', data=json.dumps(data), headers=headers)
@@ -114,5 +114,5 @@ class UserSchema(Schema):
     password = fields.String(validate=lambda n: len(n) >= 5)
 
     @post_load
-    def make_object(self, data):
+    def make_object(self, data, many, partial):
         return User(**data)


### PR DESCRIPTION
Hey @viniciuschiele,

Thanks for creating and maintaining this library :t-rex: 

This PR is to update to the latest version of marshmallow available. 
I looked into this as I was having strange issue with the post_dump method. Basically it was silently swallowing an error in marshmallow 2.* versions. I've tested locally myself and everything I've checked seems to work as expected just the marshmallow syntax has changed in some places so my code needs updating.
With 3.* this issue is fixed as well as a lot more improvements it pulls in.

This change is not backward compatible so would require either a major version release or maybe even a new package in pypi.

I've also extracted the logic from flask `_compat` so we can upgrade to flask v2.0.3

Let me know what you think
